### PR TITLE
vyatta-cfg-dhcp-server: Bug #160

### DIFF
--- a/scripts/system/dhcpd-config.pl
+++ b/scripts/system/dhcpd-config.pl
@@ -818,7 +818,8 @@ EOM
                                 && defined($mac_address)
                                 && $mac_address ne '' )
                             {
-                                $genout .= "\t\thost $static_mapping {\n";
+                                my $prefix = $name."_";
+                                $genout .= "\t\thost $prefix$static_mapping {\n";
                                 $genout .= "\t\t\tfixed-address $ip_address;\n";
                                 $genout .=
                                   "\t\t\thardware ethernet $mac_address;\n";


### PR DESCRIPTION
vyatta-cfg-dhcp-server: prefix host with shared-network-name

Host declarations in dhcpd.conf are global and not limited to the scope
they are defined in, so prefix the value given for a static mapping
with the shared-network-name to give a unique host entry in dhcpd.conf
for every static mapping.  The configuration file format and syntax
remains as it is, it is just the dhcpd.conf file produced as a result
that contains the prefix.

This patch also requires the patch for lib/DHCPServerOPMode.pm so the
prefix for this is stripped from the lease on "show dhcp server leases"
,at least for an output that stays consistent with the values in the
configuration file.

Bug #160 http://bugzilla.vyos.net/show_bug.cgi?id=160
