### PR TITLE
Adding dynamic hostfile-updates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -6,6 +6,7 @@ sbin_SCRIPTS += scripts/system/dhcpd-config.pl
 sbin_SCRIPTS += scripts/system/dhcpdv6-config.pl
 sbin_SCRIPTS += scripts/system/dhcpd.init
 sbin_SCRIPTS += scripts/system/dhcpdv6.init
+sbin_SCRIPTS += scripts/system/on-dhcp-event.sh
 
 curverdir = $(sysconfdir)/config-migrate/current
 curver_DATA = cfg-version/dhcp-server@4

--- a/scripts/system/on-dhcp-event.sh
+++ b/scripts/system/on-dhcp-event.sh
@@ -1,0 +1,98 @@
+#!/bin/bash
+
+# This script came from ubnt.com forum user "bradd" in the following post
+# http://community.ubnt.com/t5/EdgeMAX/Automatic-DNS-resolution-of-DHCP-client-names/td-p/651311
+# It has been modified by Ubiquiti to update the /etc/host file 
+# instead of adding to the CLI.
+# Thanks to forum user "itsmarcos" for bug fix & improvements
+# Thanks to forum user "ruudboon" for multiple domain fix
+# Thanks to forum user "chibby85" for expire patch and static-mapping
+
+if [ $# -lt 5 ]; then
+  echo Invalid args
+  logger -s -t on-dhcp-event "Invalid args \"$@\""
+  exit 1 
+fi
+
+action=$1
+client_name=$2
+client_ip=$3
+client_mac=$4
+domain=$5
+file=/etc/hosts
+changes=0
+
+if [ "$domain" == "..YYZ!" ]; then
+    client_fqdn_name=$client_name
+    client_search_expr=$client_name
+else
+    client_fqdn_name=$client_name.$domain
+    client_search_expr="$client_name\\.$domain"
+fi
+
+case "$action" in
+  commit) # add mapping for new lease
+    echo "- new lease event, setting static mapping for host "\
+         "$client_fqdn_name (MAC=$client_mac, IP=$client_ip)"
+    #
+    # grep fails miserably with \t in the search expression.
+    # In the following line one <Ctrl-V> <TAB> is used after $client_search_expr
+    # followed by a single space
+    grep -q " $client_search_expr	 #on-dhcp-event " $file
+    if [ $? == 0 ]; then
+       echo pattern found, removing
+       wc1=`cat $file | wc -l`
+       sudo sed -i "/ $client_search_expr\t #on-dhcp-event /d" $file
+       wc2=`cat $file | wc -l`
+       if [ "$wc1" -eq "$wc2" ]; then
+         echo No change
+       fi
+    else
+       echo pattern NOT found
+    fi
+    
+    # check if hostname already exists (e.g. a static host mapping)
+    # if so don't overwrite
+    grep -q " $client_search_expr	 " $file
+    if [ $? == 0 ]; then
+       echo host $client_fqdn_name already exists, exiting
+       exit 1
+    fi
+
+    line="$client_ip\t $client_fqdn_name\t #on-dhcp-event $client_mac"
+    sudo sh -c "echo -e '$line' >> $file"
+    ((changes++))
+    echo Entry was added
+    ;;
+
+  release) # delete mapping for released address
+    echo "- lease release event, deleting static mapping for host $client_fqdn_name"
+    wc1=`cat $file | wc -l`
+    sudo sed -i "/ $client_search_expr\t #on-dhcp-event /d" $file   
+    wc2=`cat $file | wc -l`
+    if [ "$wc1" -eq "$wc2" ]; then
+      echo No change
+    else
+      echo Entry was removed
+      ((changes++))      
+    fi
+    ;;
+
+  *)
+    logger -s -t on-dhcp-event "Invalid command \"$1\""
+    exit 1;
+    ;;
+esac
+
+if [ $changes -gt 0 ]; then
+  echo Success
+  pid=`cat /var/run/dnsmasq/dnsmasq.pid`
+  if [ -n "$pid" ]; then
+     sudo kill -SIGHUP $pid
+  fi
+else
+  echo No changes made
+fi
+exit 0
+
+

--- a/templates/service/dhcp-server/hostfile-update/node.def
+++ b/templates/service/dhcp-server/hostfile-update/node.def
@@ -1,0 +1,8 @@
+type:  txt
+default:  "disable"
+help: Option to make DHCP server update /etc/host file per lease
+syntax:expression: ($VAR(@) == "disable" || $VAR(@) == "enable" ) ; \
+"Invalid keyword $VAR(@) for hostfile-update. Specify 'enable' or 'disable'"
+allowed: echo "enable disable"
+val_help: enable; Enable updating /etc/host file (default)
+val_help: disable; Disable updating /etc/host file


### PR DESCRIPTION
Bug #511: Add Dynamic DNS for DHCP Server

The purpose of these changes is to allow a sort of dynamic DNS update to the /etc/hosts file from the dhcp server in VyOS. Since VyOS has DNS capabilities provided by dnsmasq using /etc/hosts and then utilizes a separate DHCP server the two do not talk to each other by default and host names obtained via DHCP are never entered into /etc/hosts. This prevents other systems from being able to do a lookup based on client hostnames or for a host to automatically configure a reverse DNS entry locally for its address. For every release of VyOS since November I have been manually adding this every time without any undesired side affects. I wanted to push this upstream since I think it could be useful for others. I have made the required changes in both lithium and helium.

Used the Ubiquiti Networks EdgeOS to commit the dynamic DHCP server host file changes.
This was originally provided on their forum. Credits posted below.

Added the following files:
scripts/system/on-dhcp-event.sh
templates/service/dhcp-server/hostfile-update/node.def

Modified these files:
Makefile.am
scripts/system/dhcpd-config.pl

The changes here came from ubnt.com forum user "bradd" in the following post
http://community.ubnt.com/t5/EdgeMAX/Automatic-DNS-resolution-of-DHCP-client-names/td-p/651311
It has been modified by Ubiquiti to update the /etc/host file
instead of adding to the CLI.
Thanks to ubnt.com forum user "itsmarcos" for bug fix & improvements
Thanks to ubnt.com forum user "ruudboon" for multiple domain fix
Thanks to ubnt.com forum user "chibby85" for expire patch and static-mapping
