### PR TITLE
Beryllium

### DIFF
--- a/debian/control
+++ b/debian/control
@@ -7,7 +7,7 @@ Standards-Version: 3.7.2
 
 Package: vyatta-cfg-dhcp-server
 Architecture: all
-Depends: vyatta-dhcp3-server (>= 3.0.6.dfsg-1),
+Depends: isc-dhcp-server,
  vyatta-cfg (>= 0.15.33),
  vyatta-bash | bash (>= 3.1),
  sed (>= 4.1.5),

--- a/scripts/system/dhcpd-config.pl
+++ b/scripts/system/dhcpd-config.pl
@@ -189,6 +189,7 @@ EOM
             }
 
             $genout .= "shared-network $name {\n";
+	    $genout .= "\tset PoolName = \"$name\";\n";
 
             my @subnets = $vcDHCP->listNodes("$name subnet");
             if (@subnets == 0) {

--- a/scripts/system/dhcpd.init
+++ b/scripts/system/dhcpd.init
@@ -12,7 +12,7 @@ start() {
 	  exit 1
 	fi
 
-	OUTPUT=`start-stop-daemon --start --make-pidfile --pidfile $PIDFILE -b --exec /usr/sbin/dhcpd3 \
+	OUTPUT=`start-stop-daemon --start --make-pidfile --pidfile $PIDFILE -b --exec /usr/sbin/dhcpd \
 	-- -f -pf /var/run/dhcpd-unused.pid -cf $CONFIGFILE -lf /config/dhcpd.leases 2>&1`
 	PID=`cat $PIDFILE 2>/dev/null`
 	if [ ! -d "/proc/$PID" ]; then

--- a/scripts/system/dhcpdv6-config.pl
+++ b/scripts/system/dhcpdv6-config.pl
@@ -179,6 +179,7 @@ sub push_list {
 
 my @push_arr = (
     [ "shared-network-name *", \&write_cf, "shared-network VAR-2 {\n" ],
+    [ "shared-network-name *", \&write_cf, "    set PoolName = \"VAR-2\";\n" ],
     [ "shared-network-name * subnet *", \&write_cf, "    subnet6 VAR-4 {\n" ],
     [ "shared-network-name * subnet * static-mapping *", \&write_cf, "        host VAR-6 {\n" ],
     [ "shared-network-name * subnet * address-range prefix *", \&write_cf, "        range6 VAR-7" ],

--- a/scripts/system/dhcpdv6.init
+++ b/scripts/system/dhcpdv6.init
@@ -15,7 +15,7 @@ start() {
 
     echo "Starting the DHCPv6 server..."
     OUTPUT=`start-stop-daemon --start --make-pidfile --pidfile $PIDFILE -b \
-	--exec /usr/sbin/dhcpd3 -- -6 -f -pf /var/run/dhcpdv6-unused.pid \
+	--exec /usr/sbin/dhcpd -- -6 -f -pf /var/run/dhcpdv6-unused.pid \
 	-cf $CONFIGFILE -lf /config/dhcpdv6.leases 2>&1`
     PID=`cat $PIDFILE 2>/dev/null`
     if [ ! -d "/proc/$PID" ]; then


### PR DESCRIPTION
This is is the start of a couple of changes that will remove the need for vyatta-dhcp3.

The only differences I could find between vyatta-dhcp3 and ISC upstream was patch to keep track of which dhcp pool each lease belongs to by adding #shared-network: name in dhcpd.leases.
That need can be resolved by using variables in dhcpd/dhcpv6.conf.
The other thing is /var/log/dhcpd.status, but I couldn't find any other reference to that file, so I doubt it's used at all.
