### PR TITLE
Fix op help text

### DIFF
--- a/templates/service/dhcp-server/shared-network-name/node.tag/subnet/node.tag/failover/name/node.def
+++ b/templates/service/dhcp-server/shared-network-name/node.tag/subnet/node.tag/failover/name/node.def
@@ -1,3 +1,3 @@
 type: txt
-help: DHCP failover peer name [REQUIRED]
+help: An unique identifier for the failover relationship (shared). [REQUIRED]
 syntax:expression: pattern $VAR(@) "^[-_a-zA-Z0-9.]+$" ; "invalid failover peer name \"$VAR(@)\""


### PR DESCRIPTION
http://tools.ietf.org/html/draft-ietf-dhc-failover-12#page-124 section 1.2.22
set in ISC dhcpd by https://github.com/vyos/vyatta-cfg-dhcp-server/blob/current/scripts/system/dhcpd-config.pl#L810
however http://linux.die.net/man/8/dhcpd doesn't mention "failover peer", I assume this is the legacy syntax since it is/was a draft for very long-time which different protocol versions in DHCPd. If we update our package we might have to adjust our dhcpd-config.pl accordingly.
