### PR TITLE
Fixup - using only one pid file.

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+vyatta-cfg-dhcp-server (0.12.36+vyos2+current3) unstable; urgency=medium
+
+  * Some fixup on init script.
+
+ -- Mihail Vasilev <mick@corp.linkintel.ru>  Wed, 24 May 2017 16:37:00 +0300
+
 vyatta-cfg-dhcp-server (0.12.36+vyos2+current2) unstable; urgency=medium
 
   * Use ISC DHCP rather than the vyatta version.

--- a/scripts/system/dhcpd.init
+++ b/scripts/system/dhcpd.init
@@ -14,7 +14,7 @@ start() {
 	fi
 
 	OUTPUT=`start-stop-daemon --start --make-pidfile --pidfile $PIDFILE -b --exec $DHCPD \
-	-- -f -pf /var/run/dhcpd-unused.pid -cf $CONFIGFILE -lf /config/dhcpd.leases 2>&1`
+	-- -f -pf $PIDFILE -cf $CONFIGFILE -lf /config/dhcpd.leases 2>&1`
 	PID=`cat $PIDFILE 2>/dev/null`
 	if [ ! -d "/proc/$PID" ]; then
 	  if [ "$OUTPUT" == "" ]; then


### PR DESCRIPTION
Tends to hang on
restart service dhcp-server
without it in some unclear circumstances.