### PR TITLE
Update dhcpd-config.pl

### DIFF
--- a/scripts/system/dhcpd-config.pl
+++ b/scripts/system/dhcpd-config.pl
@@ -117,8 +117,7 @@ if ($vcDHCP->exists('.')) {
     my $disabled_val = $vcDHCP->returnValue('disabled');
     if (defined($disabled_val) && $disabled_val eq 'true') {
         my $msg = <<"EOM";
-Warning:  DHCP server will be deactivated because 
-'service dhcp-server disabled' is 'true'
+Warning:  DHCP server will be deactivated because 'service dhcp-server disabled' is 'true'
 EOM
         print STDERR $msg;
         $disabled = 1;


### PR DESCRIPTION
fixing a bug on my EdgeRouter Pro (ver: 1.9.1, build: 4939098 from 2016-12-14) that causes dhcp-server to stop serving addresses. I can see the same code on vyos thus pulling here.

ocassionally my router stops serving clients with dynamic addresses. syslog shows the following messages:
```
    dhcpd: /opt/vyatta/etc/dhcpd.conf line 33: expecting a declaration
    dhcpd: # Warning:  DHCP server will be deactivated because
```
in /opt/vyatta/etc/dhcpd.conf I can see lines 32-33 containing the following:
```
    # Warning:  DHCP server will be deactivated because
    'service dhcp-server disabled' is 'true'
```
and the very first line of this config file introduces:
```
    # generated by /opt/vyatta/sbin/dhcpd-config.pl
```
trying to fix that by removing a line break in the middle of the config comment line