### PR TITLE
T568: reload pdns on lease handout

### DIFF
--- a/scripts/system/on-dhcp-event.sh
+++ b/scripts/system/on-dhcp-event.sh
@@ -86,9 +86,9 @@ esac
 
 if [ $changes -gt 0 ]; then
   echo Success
-  pid=`cat /var/run/dnsmasq/dnsmasq.pid`
+  pid=`pgrep pdns_recursor`
   if [ -n "$pid" ]; then
-     sudo kill -SIGHUP $pid
+     sudo rec_control reload-zones
   fi
 else
   echo No changes made


### PR DESCRIPTION
DHCP hostfile writer is telling dnsmasq to reload - we no longer use dnsmasq.

This patch changes the script to tell pdns_recursor to reload its zonefiles instead.