### PR TITLE
Update node.def

### DIFF
--- a/templates/service/dhcp-server/hostfile-update/node.def
+++ b/templates/service/dhcp-server/hostfile-update/node.def
@@ -4,5 +4,5 @@ help: Option to make DHCP server update /etc/host file per lease
 syntax:expression: ($VAR(@) == "disable" || $VAR(@) == "enable" ) ; \
 "Invalid keyword $VAR(@) for hostfile-update. Specify 'enable' or 'disable'"
 allowed: echo "enable disable"
-val_help: enable; Enable updating /etc/host file (default)
-val_help: disable; Disable updating /etc/host file
+val_help: enable; Enable updating /etc/hosts file
+val_help: disable; Disable updating /etc/hosts file (default)


### PR DESCRIPTION
Making help text consistent with default setting: disable
Fixing typo /etc/host(s)